### PR TITLE
20차 스프린트 Pull-Request

### DIFF
--- a/src/main/java/com/bluewhaletech/Ourry/config/SecurityConfig.java
+++ b/src/main/java/com/bluewhaletech/Ourry/config/SecurityConfig.java
@@ -75,13 +75,16 @@ public class SecurityConfig {
                 .requestMatchers("/member/passwordReset").permitAll() // 비밀번호 재설정 API
                 .requestMatchers("/member/reissueToken").permitAll() // JWT 토큰 재발급 API
 
+                /* 비회원 권한 설정 */
                 .requestMatchers("/article/searchQuestionList").permitAll()
                 .requestMatchers("/article/getQuestionList").permitAll()
                 .requestMatchers("/article/getQuestionList/{categoryId}").permitAll()
-//                .requestMatchers("/article/getQuestionDetail").permitAll()
-//                .requestMatchers("/article/addQuestion").permitAll()
-//                .requestMatchers("/article/answerQuestion").permitAll()
-//                .requestMatchers("/article/addReply").permitAll()
+                .requestMatchers("/article/getQuestionDetail").permitAll()
+
+                /* MEMBER 권한 설정 */
+                .requestMatchers("/article/addQuestion").hasAnyRole("MEMBER", "ADMIN")
+                .requestMatchers("/article/answerQuestion").hasAnyRole("MEMBER", "ADMIN")
+                .requestMatchers("/article/addReply").hasAnyRole("MEMBER", "ADMIN")
                 .anyRequest().authenticated() // 위 URL 목록을 제외한 나머지 요청에 대해 인증 수행
         );
         return http.build();

--- a/src/main/java/com/bluewhaletech/Ourry/controller/ArticleController.java
+++ b/src/main/java/com/bluewhaletech/Ourry/controller/ArticleController.java
@@ -12,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Optional;
+
 @Controller
 public class ArticleController {
     private final ArticleServiceImpl articleService;
@@ -40,7 +42,10 @@ public class ArticleController {
 
     @GetMapping("/article/getQuestionDetail")
     public ResponseEntity<Object> getQuestionDetail(HttpServletRequest request, @RequestParam(value = "questionId") Long questionId) {
-        String email = tokenProvider.getTokenSubject(request.getHeader("Authorization").substring(7));
+        String email = null;
+        if(request.getHeader("Authorization") != null) {
+            email = tokenProvider.getTokenSubject(request.getHeader("Authorization").substring(7));
+        }
         return ResponseEntity.ok().body(articleService.getQuestionDetail(email, questionId));
     }
 

--- a/src/main/java/com/bluewhaletech/Ourry/controller/ArticleController.java
+++ b/src/main/java/com/bluewhaletech/Ourry/controller/ArticleController.java
@@ -12,8 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Optional;
-
 @Controller
 public class ArticleController {
     private final ArticleServiceImpl articleService;
@@ -72,8 +70,8 @@ public class ArticleController {
 
     @PostMapping("/article/setAlarmOnQuestion")
     public ResponseEntity<Object> setAlarmOnQuestion(HttpServletRequest request, @RequestBody AlarmSettingDTO dto) {
-        String accessToken = request.getHeader("Authorization").substring(7);
-        articleService.setAlarmOnQuestion(accessToken, dto);
+        String email = tokenProvider.getTokenSubject(request.getHeader("Authorization").substring(7));
+        articleService.setAlarmOnQuestion(email, dto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/bluewhaletech/Ourry/dto/QuestionDetailDTO.java
+++ b/src/main/java/com/bluewhaletech/Ourry/dto/QuestionDetailDTO.java
@@ -21,10 +21,13 @@ public class QuestionDetailDTO {
     private String category;
 
     @NotBlank
+    private Long memberId;
+
+    @NotBlank
     private String nickname;
 
     @NotBlank
-    private String alarmYN;
+    private char alarmYN;
 
     @NotBlank
     private char polled;

--- a/src/main/java/com/bluewhaletech/Ourry/repository/AlarmJpaRepository.java
+++ b/src/main/java/com/bluewhaletech/Ourry/repository/AlarmJpaRepository.java
@@ -14,5 +14,5 @@ public interface AlarmJpaRepository extends org.springframework.data.repository.
     Alarm findByMemberAndQuestion(Member member, Question question);
 
     @Query(value = "select a.alarmYN from Alarm a where a.member = :member and a.question = :question")
-    String findAlarmYNByMemberAndQuestion(@Param("member") Member member, @Param("question") Question question);
+    char findAlarmYNByMemberAndQuestion(@Param("member") Member member, @Param("question") Question question);
 }

--- a/src/main/java/com/bluewhaletech/Ourry/service/ArticleService.java
+++ b/src/main/java/com/bluewhaletech/Ourry/service/ArticleService.java
@@ -18,4 +18,6 @@ public interface ArticleService {
     void answerQuestion(String email, QuestionResponseDTO dto);
 
     void addReply(String email, ReplyRegistrationDTO dto);
+
+    void setAlarmOnQuestion(String email, AlarmSettingDTO dto);
 }

--- a/src/main/java/com/bluewhaletech/Ourry/service/ArticleServiceImpl.java
+++ b/src/main/java/com/bluewhaletech/Ourry/service/ArticleServiceImpl.java
@@ -349,14 +349,15 @@ public class ArticleServiceImpl implements ArticleService {
         }
     }
 
+    @Override
     @Transactional
-    public void setAlarmOnQuestion(String accessToken, AlarmSettingDTO dto) {
-        Member member = Optional.ofNullable(memberJpaRepository.findByEmail(accessToken))
+    public void setAlarmOnQuestion(String email, AlarmSettingDTO dto) {
+        Member member = Optional.ofNullable(memberJpaRepository.findByEmail(email))
                 .orElseThrow(() -> new MemberNotFoundException("회원 정보가 존재하지 않습니다."));
         Question question = Optional.ofNullable(questionRepository.findOne(dto.getQuestionId()))
                 .orElseThrow(() -> new QuestionNotFoundException("질문 정보가 존재하지 않습니다."));
         Alarm alarm = Optional.ofNullable(alarmJpaRepository.findByMemberAndQuestion(member, question))
-                .orElseThrow(() -> new AlarmSettingNotFoundException("질문에 대한 알림 설정 기록이 존재하지 않습니다."));
+                .orElseThrow(() -> new AlarmSettingNotFoundException("질문에 대해 투표한 기록이 존재하지 않습니다."));
         alarm.setAlarmYN(dto.getAlarmYN());
     }
 

--- a/src/main/java/com/bluewhaletech/Ourry/service/ArticleServiceImpl.java
+++ b/src/main/java/com/bluewhaletech/Ourry/service/ArticleServiceImpl.java
@@ -154,6 +154,13 @@ public class ArticleServiceImpl implements ArticleService {
             }
         }
 
+        /* 비회원과 미응답자는 솔루션 및 답글 정보 확인 불가 */
+        int solutionCnt = solutions.size();
+        int replyCnt = replies.size();
+        if(polled == 'N') {
+            solutions = null;
+            replies = null;
+        }
         return QuestionDetailDTO.builder()
                 .title(question.getTitle())
                 .content(question.getContent())
@@ -163,7 +170,7 @@ public class ArticleServiceImpl implements ArticleService {
                 .alarmYN(alarmYN)
                 .polled(polled)
                 .pollCnt(polls.size())
-                .responseCnt(solutions.size()+replies.size())
+                .responseCnt(solutionCnt+replyCnt)
                 .createdAt(question.getCreatedAt())
                 .choices(choices)
                 .solutions(solutions)

--- a/src/main/java/com/bluewhaletech/Ourry/service/ArticleServiceImpl.java
+++ b/src/main/java/com/bluewhaletech/Ourry/service/ArticleServiceImpl.java
@@ -97,7 +97,7 @@ public class ArticleServiceImpl implements ArticleService {
         /* 회원 투표유무 확인 */
         char polled = 'A'; // 작성자(A)
         if(member == null) {
-            polled = 'U'; // 비회원(U)
+            polled = 'N'; // 미투표(N)
         } else if(!questionJpaRepository.existsByMemberAndQuestionId(member, questionId)) {
             polled = pollJpaRepository.existsByMemberAndQuestion(member, question) ? 'Y' : 'N'; // 투표(Y), 미투표(N)
         }

--- a/src/main/java/com/bluewhaletech/Ourry/service/ArticleServiceImpl.java
+++ b/src/main/java/com/bluewhaletech/Ourry/service/ArticleServiceImpl.java
@@ -76,21 +76,29 @@ public class ArticleServiceImpl implements ArticleService {
 
     @Override
     public QuestionDetailDTO getQuestionDetail(String email, Long questionId) {
-        /* 회원 존재유무 확인 */
-        Member member = Optional.ofNullable(memberJpaRepository.findByEmail(email))
-                .orElseThrow(() -> new MemberNotFoundException("회원 정보가 존재하지 않습니다."));
+        /* 비회원 확인 */
+        Member member = null;
+        if(email != null) {
+            /* 회원 존재유무 확인 */
+            member = Optional.ofNullable(memberJpaRepository.findByEmail(email))
+                    .orElseThrow(() -> new MemberNotFoundException("회원 정보가 존재하지 않습니다."));
+        }
 
         /* 질문 존재유무 확인 */
         Question question = Optional.ofNullable(questionRepository.findOne(questionId))
                 .orElseThrow(() -> new QuestionNotFoundException("질문 정보가 존재하지 않습니다."));
 
-        /* 알림 수신여부 가져오기 */
-        Alarm alarm = Optional.ofNullable(alarmJpaRepository.findByMemberAndQuestion(member, question))
-                .orElseThrow(() -> new AlarmSettingNotFoundException("질문에 대한 알림 설정 기록이 존재하지 않습니다."));
+        /* 알림 수신유무 확인 */
+        char alarmYN = 'N'; // 미수신(N)
+        if(member != null && alarmJpaRepository.existsAlarmByMemberAndQuestion(member, question)) {
+            alarmYN = alarmJpaRepository.findAlarmYNByMemberAndQuestion(member, question);
+        }
 
         /* 회원 투표유무 확인 */
         char polled = 'A'; // 작성자(A)
-        if(!questionJpaRepository.existsByMemberAndQuestionId(member, questionId)) {
+        if(member == null) {
+            polled = 'U'; // 비회원(U)
+        } else if(!questionJpaRepository.existsByMemberAndQuestionId(member, questionId)) {
             polled = pollJpaRepository.existsByMemberAndQuestion(member, question) ? 'Y' : 'N'; // 투표(Y), 미투표(N)
         }
 
@@ -150,8 +158,9 @@ public class ArticleServiceImpl implements ArticleService {
                 .title(question.getTitle())
                 .content(question.getContent())
                 .category(question.getCategory().getName())
+                .memberId(question.getMember().getMemberId())
                 .nickname(question.getMember().getNickname())
-                .alarmYN(alarm.getAlarmYN())
+                .alarmYN(alarmYN)
                 .polled(polled)
                 .pollCnt(polls.size())
                 .responseCnt(solutions.size()+replies.size())
@@ -204,7 +213,7 @@ public class ArticleServiceImpl implements ArticleService {
         /* 회원 존재유무 확인 */
         Member member = Optional.ofNullable(memberJpaRepository.findByEmail(email))
                 .orElseThrow(() -> new MemberNotFoundException("회원 정보가 존재하지 않습니다."));
-        
+
         /* 질문 존재유무 확인 */
         Question question = Optional.ofNullable(questionRepository.findOne(dto.getQuestionId()))
                 .orElseThrow(() -> new QuestionNotFoundException("질문 정보가 존재하지 않습니다."));
@@ -234,7 +243,7 @@ public class ArticleServiceImpl implements ArticleService {
                 .choice(choice)
                 .build();
         pollRepository.save(poll);
-        
+
         String opinion = dto.getOpinion();
         if(opinion != null) {
             /* FCM */
@@ -246,7 +255,7 @@ public class ArticleServiceImpl implements ArticleService {
                         .build());
 
                 /* 질문에 대한 알림 수신여부 검사 */
-                if("Y".equals(alarmJpaRepository.findAlarmYNByMemberAndQuestion(question.getMember(), question))) {
+                if(alarmJpaRepository.findAlarmYNByMemberAndQuestion(question.getMember(), question) == 'Y') {
                     /* 질문 작성자에게 발급된 FcmToken 가져오기 */
                     String questionAuthorEmail = question.getMember().getEmail();
                     String fcmToken = Optional.ofNullable(memberJpaRepository.findFcmTokenByEmail(questionAuthorEmail))
@@ -292,7 +301,7 @@ public class ArticleServiceImpl implements ArticleService {
         list.add(questionAuthorFcmToken);
 
         /* 질문에 대한 알림 수신여부 검사 */
-        if("Y".equals(alarmJpaRepository.findAlarmYNByMemberAndQuestion(poll.getMember(), poll.getQuestion()))) {
+        if(alarmJpaRepository.findAlarmYNByMemberAndQuestion(poll.getMember(), poll.getQuestion()) == 'Y') {
             /* 솔루션 작성자에게 발급된 FCM 토큰 가져오기 */
             String solutionAuthorEmail = poll.getMember().getEmail();
             String solutionAuthorFcmToken = Optional.ofNullable(memberJpaRepository.findFcmTokenByEmail(solutionAuthorEmail))
@@ -311,7 +320,7 @@ public class ArticleServiceImpl implements ArticleService {
         /* 현재 답글을 제외한 답글 목록 불러오기 */
         for(Reply r : replyJpaRepository.findBySolutionExceptReplier(solution, reply)) {
             /* 질문에 대한 알림 수신여부 검사 */
-            if("Y".equals(alarmJpaRepository.findAlarmYNByMemberAndQuestion(r.getMember(), poll.getQuestion()))) {
+            if(alarmJpaRepository.findAlarmYNByMemberAndQuestion(r.getMember(), poll.getQuestion()) == 'Y') {
                 /* 솔루션에 답글을 작성한 회원들로부터 FCM 토큰 가져오기 */
                 String replyAuthorEmail = r.getMember().getEmail();
                 String replyAuthorFcmToken = Optional.ofNullable(memberJpaRepository.findFcmTokenByEmail(replyAuthorEmail))

--- a/src/main/java/com/bluewhaletech/Ourry/service/MemberService.java
+++ b/src/main/java/com/bluewhaletech/Ourry/service/MemberService.java
@@ -3,12 +3,11 @@ package com.bluewhaletech.Ourry.service;
 import com.bluewhaletech.Ourry.dto.JwtDTO;
 import com.bluewhaletech.Ourry.dto.MemberLoginDTO;
 import com.bluewhaletech.Ourry.dto.MemberRegistrationDTO;
-import jakarta.servlet.http.HttpServletResponse;
 
 public interface MemberService {
     void createAccount(MemberRegistrationDTO dto, String fcmToken) throws Exception;
 
-    JwtDTO memberLogin(MemberLoginDTO dto) throws Exception;
+    JwtDTO memberLogin(MemberLoginDTO dto, String fcmToken) throws Exception;
 
     JwtDTO reissueToken(String refreshToken) throws Exception;
 

--- a/src/main/java/com/bluewhaletech/Ourry/service/MemberServiceImpl.java
+++ b/src/main/java/com/bluewhaletech/Ourry/service/MemberServiceImpl.java
@@ -87,7 +87,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Transactional
-    public JwtDTO memberLogin(MemberLoginDTO dto) {
+    public JwtDTO memberLogin(MemberLoginDTO dto, String fcmToken) {
         /* 이메일 유효성 확인 */
         Member member = Optional.ofNullable(memberJpaRepository.findByEmail(dto.getEmail()))
                 .orElseThrow(() -> new MemberNotFoundException("등록되지 않은 이메일입니다."));
@@ -96,6 +96,9 @@ public class MemberServiceImpl implements MemberService {
         if(!passwordEncoder.matches(dto.getPassword(), member.getPassword())) {
             throw new PasswordConfirmException("비밀번호가 일치하지 않습니다.");
         }
+
+        /* 로그인할 때마다 FCM 토큰 값 갱신 */
+        member.setFcmToken(fcmToken);
 
         /* 이메일 & 비밀번호를 바탕으로 인증(Authentication) 정보 생성 및 JWT 발급 */
         return memberAuthentication(member);


### PR DESCRIPTION
#### 작업 시간
- 약 5H (2024-04-27 ~ 2024-04-28)

#### 개발 내용
- 질문 상세화면 접근 시 응답내용 분리 (http://localhost:8080/article/getQuestionDetail?{questionId}
  * 비회원과 미응답자는 질문 상세화면 접근 시 솔루션 및 답글 정보를 확인 못하도록 변경
  * 비회원과미응답자가 요청을 보낸 경우에는 투표유무 및 알림수신유무 값을 N으로 고정
  * 응답자는 투표 직후 질문상세화면 재접근 시 투표유무 및 알림수신유무 값을 Y로 변경

#### 수정 내용
- 로그인 시 사용자가 전송한 FCM 토큰으로 기존 데이터 갱신